### PR TITLE
Mixed Cloud Particle Opacities

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -39,7 +39,9 @@ def test_basic_virga():
 
     # ==== Test mixed clouds with variable fsed =========================================
     # initialise atmosphere
-    a = jdi.Atmosphere(['MnS', 'SiO2'], fsed={'MnS':1, 'SiO2':1}, mh=1, mmw=2.2, param='exp', b=3)
+    a = jdi.Atmosphere(
+        ['MnS', 'SiO2'], fsed={'MnS':1, 'SiO2':1}, mh=1, mmw=2.2, param='exp', b=3
+    )
     a.gravity(gravity=7.460, gravity_unit=u.Unit('m/(s**2)'))
     a.ptk(df=jdi.hot_jupiter())
     # calculate cloud profile
@@ -63,7 +65,8 @@ def test_basic_virga():
     # a.ptk(df=jdi.hot_jupiter())
     # # calculate cloud profile
     # all_out = jdi.compute(a, as_dict=True, directory=os.path.dirname(__file__),
-    #                       og_solver=False, analytical_rg=False, og_vfall=False, do_virtual=False)
+    #                       og_solver=False, analytical_rg=False, og_vfall=False,
+    #                       do_virtual=False)
     # assert np.isclose(np.sum(all_out['condensate_mmr']), 1.843949389772658e-05)
 
 def test_gamma():
@@ -114,11 +117,13 @@ def test_mixed_clouds():
     a.gravity(gravity=7.460, gravity_unit=u.Unit('m/(s**2)'))
     a.ptk(df=jdi.hot_jupiter())
     # calculate cloud profile
-    all_out = jdi.compute(a, as_dict=True, directory=os.path.dirname(__file__), quick_mix=True)
+    all_out = jdi.compute(
+        a, as_dict=True, directory=os.path.dirname(__file__), mixed_opacity_type='quick'
+    )
     # test the output
     tested_outputs = [
-        'condensate_mmr', 'mean_particle_r', 'droplet_eff_r', 'column_density', 'mixing_length',
-        'altitude',
+        'condensate_mmr', 'mean_particle_r', 'droplet_eff_r', 'column_density',
+        'mixing_length', 'altitude',
     ]
     expected_outputs = [
         0.004800222240714903, 261.57706522293745, 869.4505664824956, 11291.153198839147,
@@ -130,11 +135,15 @@ def test_mixed_clouds():
 
     # ==== Test mixed clouds with variable fsed =========================================
     # initialise atmosphere
-    a = jdi.Atmosphere(['MnS', 'SiO2'], fsed={'MnS':1, 'SiO2':2, 'mixed': 3}, mh=1, mmw=2.2, mixed=True)
+    a = jdi.Atmosphere(
+        ['MnS', 'SiO2'], fsed={'MnS':1, 'SiO2':2, 'mixed': 3}, mh=1, mmw=2.2, mixed=True
+    )
     a.gravity(gravity=7.460, gravity_unit=u.Unit('m/(s**2)'))
     a.ptk(df=jdi.hot_jupiter())
     # calculate cloud profile
-    all_out = jdi.compute(a, as_dict=True, directory=os.path.dirname(__file__), quick_mix=True)
+    all_out = jdi.compute(
+        a, as_dict=True, directory=os.path.dirname(__file__), mixed_opacity_type='quick'
+    )
     # test the output
     tested_outputs = [
         'condensate_mmr', 'mean_particle_r', 'droplet_eff_r', 'column_density',

--- a/virga/justdoit.py
+++ b/virga/justdoit.py
@@ -414,12 +414,33 @@ def calc_optics(nwave, qc, qt, rg, reff, ndz, radius, dr, bin_min, bin_max, qext
     g0 = np.zeros((nz, nwave))  # asymmetry parameter
 
     # Mixed particle working array
-    ndr_mixed = np.zeros((nz, nrad, len(gas_name[:-1])))  # number density of mixed part.
+    ndr_mixed = np.zeros((nz, nrad, ngas-1))  # number density of mixed part.
     vmr_test = np.ones((2, nrad, ngas-1)) * 2  # check if mixed opacities need recalc.
     qextm = np.zeros((nz, nw, nrad))  # mixed cloud particle extinction coefficient
     qscam = np.zeros((nz, nw, nrad))  # mixed cloud particle scattering coefficient
     cos_qscam = np.zeros((nz, nw, nrad)) # mixed cloud particle asymmetry coefficient
     qet, qst, cqt = None, None, None  # default assignment
+
+    # default value for mixed opacity
+    if mixed_opacity_type is None:
+        mixed_opacity_type = 'multi_modal'
+
+    ma = Mieai(use_ai=False)  # set up mieai class
+    for g, gas in enumerate(gas_name):
+        if gas =='mixed':
+            continue
+        vmr2 = {}
+        for v, gas2 in enumerate(gas_name):
+            if gas2 =='mixed':
+                continue
+            if gas2 == gas:
+                vmr2[gas2] = np.ones((len(radius),))
+            else:
+                vmr2[gas2] = np.zeros((len(radius),))
+        qet, qst, cqt = ma.grid_efficiencies(wave, radius * 1e4, vmr2)
+        qext[:, :, g] = qet.T
+        qscat[:, :, g] = qst.T
+        cos_qscat[:, :, g] = cqt.T
 
     # ===================================================================================
     # Mixed opacity precalculation
@@ -433,7 +454,7 @@ def calc_optics(nwave, qc, qt, rg, reff, ndz, radius, dr, bin_min, bin_max, qext
     if mixed:
 
         # ==== Check if MieAi is loaded and can be used
-        if mixed_opacity_type in [None, 'multi_modal', 'single_model'] and not mieai_loaded:
+        if mixed_opacity_type in ['multi_modal', 'single_model'] and not mieai_loaded:
             print('WARNING: MieAi not loaded, change opacity mixing to "quick".')
             mixed_opacity_type = 'quick'
         else:
@@ -447,14 +468,14 @@ def calc_optics(nwave, qc, qt, rg, reff, ndz, radius, dr, bin_min, bin_max, qext
             ngas -= 1  # remove 'mixed' entry which is always the last one
 
         # ==== Mixed particles
-        elif mixed_opacity_type in ['single_model', 'multi_model']:
+        elif mixed_opacity_type in ['single_modal', 'multi_modal']:
             for z in range(nz):
                 # reset working variables
                 vmr = {}  # VMR dict for mieai
                 vmr_tot = 0  # check if there are any cloud partilces
 
                 # ==== Calculate size distributions for each material (including mixed)
-                for g, gas in enumerate(gas_name):
+                for g, gas in enumerate(gas_name[:-1]):
                     # get size distribution of particles
                     if dist == 'lognormal':
                         arg1 = dr / (np.sqrt(2. * np.pi) * radius * np.log(sig))
@@ -464,19 +485,19 @@ def calc_optics(nwave, qc, qt, rg, reff, ndz, radius, dr, bin_min, bin_max, qext
                         B = gamma_A / rg[z, g]
                         lf = gamma_A * np.log(B) - gammaln(gamma_A)
                         vl = dr * np.exp(lf + (gamma_A - 1) * np.log(radius) - B * radius)
-                    dist = vl / np.sum(vl)  # normalisation
-                    ndr_mixed[z, :, g] = np.nan_to_num(ndz[z, g] * dist)
+                    ndist = vl / np.sum(vl)  # normalisation
+                    ndr_mixed[z, :, g] = np.nan_to_num(ndz[z, g] * ndist)
 
-                    for g, gas in enumerate(gas_name[:-1]):
-                        if mixed_opacity_type == 'multi_modal':
-                            # get fraction from the number density VMR per bin
-                            val = ndr_mixed[z, :, g] / np.sum(ndr_mixed[z, :, :-1], axis=1)
-                        else: # mixed_opacity_type == 'single_modal'
-                            # get fraction from the total VMR
-                            val = np.ones((nrad,)) * ndz[z, g] / np.sum(ndz[z, :-1], axis=1)
-                        vmr[gas] = np.nan_to_num(val)
-                        vmr_test[0, :, g] = vmr[gas]  # remember values for next loop
-                        vmr_tot += np.sum(vmr[gas])  # check if some values are non-zero
+                for g, gas in enumerate(gas_name[:-1]):
+                    if mixed_opacity_type == 'multi_modal':
+                        # get fraction from the number density VMR per bin
+                        val = ndr_mixed[z, :, g] / np.sum(ndr_mixed[z, :], axis=1)
+                    else: # mixed_opacity_type == 'single_modal'
+                        # get fraction from the total VMR
+                        val = np.ones((nrad,)) * ndz[z, g] / np.sum(ndz[z, :-1], axis=1)
+                    vmr[gas] = np.nan_to_num(val)
+                    vmr_test[0, :, g] = vmr[gas]  # remember values for next loop
+                    vmr_tot += np.sum(vmr[gas])  # check if some values are non-zero
 
                 # ==== Check if VMRs have changed, and only then re-calculate opacity
                 if np.any(np.abs((vmr_test[0] - vmr_test[1]) / vmr_test[0]) > 1e-4):
@@ -486,17 +507,18 @@ def calc_optics(nwave, qc, qt, rg, reff, ndz, radius, dr, bin_min, bin_max, qext
 
                     # calcualte opacity using MieAi library
                     else:
-                        qet, qst, asym = ma.grid_efficiencies(wave, radius * 1e4, vmr)
-                        cqt = qet * asym  # qcos according to Virga syntax
+                        qeti, qsti, asym = ma.grid_efficiencies(wave, radius * 1e4, vmr)
+                        cqti = qeti * asym  # qcos according to Virga syntax
+                        qet, qst, cqt = qeti.T, qsti.T, cqti.T  # change format
                         # remeber the vmrs for the next run
                         vmr_test[1] = vmr_test[0]
 
                 # set values (these are the old values if vmrs have not changed)
-                qextm[z], qscam[z], cos_qscam[z] = qet.T, qst.T, cqt.T
+                qextm[z], qscam[z], cos_qscam[z] = qet, qst, cqt
 
         else:
-            raise ValueError('mixed_opacity_type not recognized (' +
-                             mixed_opacity_type + ')')
+            raise ValueError('mixed_opacity_type "' + mixed_opacity_type
+                             + '" not recognized ')
 
     # ===================================================================================
     # Calculate opacity of each cloud particle material
@@ -536,7 +558,7 @@ def calc_optics(nwave, qc, qt, rg, reff, ndz, radius, dr, bin_min, bin_max, qext
 
                 if mixed and mixed_opacity_type in ['single_modal', 'multi_modal']:
                     # only mixed entry should be considered
-                    if igas != 'mixed':
+                    if gas_name[igas] != 'mixed':
                         continue
                     for irad in range(nrad):
                         for iw in range(nwave):
@@ -632,8 +654,8 @@ def calc_optics(nwave, qc, qt, rg, reff, ndz, radius, dr, bin_min, bin_max, qext
                 opd_ext = opd_ext + ext_gas[iz, iwave, igas]
                 cos_qs = cos_qs + cqs_gas[iz, iwave, igas]
 
+                opd[iz, iwave] = opd_ext
                 if opd_scat > 0.:
-                    opd[iz,iwave] = opd_ext
                     w0[iz,iwave] = opd_scat / opd_ext
                     g0[iz,iwave] = cos_qs / opd_scat
 

--- a/virga/justdoit.py
+++ b/virga/justdoit.py
@@ -19,6 +19,9 @@ from scipy.optimize import brentq
 mieai_loaded = False
 try:
     from mieai import Mieai
+    # Mie Class is setup here since setup can take a while, while execution is
+    # much faster. This prevents reimport during itarative use of Virga
+    ma = Mieai(use_ai=False)
     mieai_loaded = True
 except:
     # Virga can be run without MieAi, but mixed opacities are not available
@@ -425,23 +428,6 @@ def calc_optics(nwave, qc, qt, rg, reff, ndz, radius, dr, bin_min, bin_max, qext
     if mixed_opacity_type is None:
         mixed_opacity_type = 'multi_modal'
 
-    ma = Mieai(use_ai=False)  # set up mieai class
-    for g, gas in enumerate(gas_name):
-        if gas =='mixed':
-            continue
-        vmr2 = {}
-        for v, gas2 in enumerate(gas_name):
-            if gas2 =='mixed':
-                continue
-            if gas2 == gas:
-                vmr2[gas2] = np.ones((len(radius),))
-            else:
-                vmr2[gas2] = np.zeros((len(radius),))
-        qet, qst, cqt = ma.grid_efficiencies(wave, radius * 1e4, vmr2)
-        qext[:, :, g] = qet.T
-        qscat[:, :, g] = qst.T
-        cos_qscat[:, :, g] = cqt.T
-
     # ===================================================================================
     # Mixed opacity precalculation
     # ===================================================================================
@@ -455,11 +441,8 @@ def calc_optics(nwave, qc, qt, rg, reff, ndz, radius, dr, bin_min, bin_max, qext
 
         # ==== Check if MieAi is loaded and can be used
         if mixed_opacity_type in ['multi_modal', 'single_model'] and not mieai_loaded:
-            print('WARNING: MieAi not loaded, change opacity mixing to "quick".')
+            print('WARNING: MieAi not installed, change opacity mixing to "quick".')
             mixed_opacity_type = 'quick'
-        else:
-            # TODO: move this outside function
-            ma = Mieai(use_ai=False)  # set up mieai class
 
         # ==== Quick mix
         # This does not use the mixed properties and assumes each material forms a
@@ -502,16 +485,14 @@ def calc_optics(nwave, qc, qt, rg, reff, ndz, radius, dr, bin_min, bin_max, qext
                 # ==== Check if VMRs have changed, and only then re-calculate opacity
                 if np.any(np.abs((vmr_test[0] - vmr_test[1]) / vmr_test[0]) > 1e-4):
                     # if there are no clouds, return no opacity
-                    # if vmr_tot <= 0:
-                    #     qet, qst, cqt = 0, 0, 0
-                    #
-                    # # calcualte opacity using MieAi library
-                    # else:
-                    qeti, qsti, asym = ma.grid_efficiencies(wave, radius * 1e4, vmr)
-                    cqti = qeti * asym  # qcos according to Virga syntax
-                    qet, qst, cqt = qeti.T, qsti.T, cqti.T  # change format
-                    # remeber the vmrs for the next run
-                    vmr_test[1] = vmr_test[0]
+                    if vmr_tot <= 0:
+                        qet, qst, cqt = 0, 0, 0
+                    # calcualte opacity using MieAi library
+                    else:
+                        qeti, qsti, asym = ma.grid_efficiencies(wave, radius * 1e4, vmr)
+                        cqti = qeti * asym  # qcos according to Virga syntax
+                        qet, qst, cqt = qeti.T, qsti.T, cqti.T  # change format
+                        vmr_test[1] = vmr_test[0]  # remeber the vmrs for the next run
 
                 # set values (these are the old values if vmrs have not changed)
                 qextm[z], qscam[z], cos_qscam[z] = qet, qst, cqt
@@ -558,16 +539,15 @@ def calc_optics(nwave, qc, qt, rg, reff, ndz, radius, dr, bin_min, bin_max, qext
 
                 if mixed and mixed_opacity_type in ['single_modal', 'multi_modal']:
                     # only mixed entry should be considered
-                    if gas_name[igas] != 'mixed':
-                        continue
-                    for irad in range(nrad):
-                        for iw in range(nwave):
-                            # total cloud particle cross section
-                            pir2ndz2 = np.pi * radius[irad]**2 * np.sum(ndr_mixed[iz, irad, :-1])
-                            # opacity of mixed particles
-                            scat_gas[iz, iw, igas] += qscam[iz, iw, irad] * pir2ndz2
-                            ext_gas[iz, iw, igas] += qextm[iz, iw, irad] * pir2ndz2
-                            cqs_gas[iz, iw, igas] += cos_qscam[iz, iw, irad] * pir2ndz2
+                    if gas_name[igas] == 'mixed':
+                        for irad in range(nrad):
+                            for iw in range(nwave):
+                                # total cloud particle cross section
+                                pir2ndz2 = np.pi * radius[irad]**2 * np.sum(ndr_mixed[iz, irad])
+                                # opacity of mixed particles
+                                scat_gas[iz, iw, igas] += qscam[iz, iw, irad] * pir2ndz2
+                                ext_gas[iz, iw, igas] += qextm[iz, iw, irad] * pir2ndz2
+                                cqs_gas[iz, iw, igas] += cos_qscam[iz, iw, irad] * pir2ndz2
 
                 elif dist == 'lognormal':
                     norm = 0.
@@ -671,7 +651,6 @@ def calc_optics(nwave, qc, qt, rg, reff, ndz, radius, dr, bin_min, bin_max, qext
         print(warning0 + warning + ' Turn off warnings by setting verbose=False.')
 
     return opd, w0, g0, opd_gas
-
 
 def calc_optics_user_r_dist(wave_in, ndz, radius, radius_unit, r_distribution,
                             qext, qscat ,cos_qscat, verbose=False):

--- a/virga/justdoit.py
+++ b/virga/justdoit.py
@@ -15,6 +15,15 @@ from scipy import optimize
 from scipy.special import polygamma, gammaln
 from scipy.optimize import brentq
 
+# ==== Load in MieAi to calculate mixed cloud opacities
+mieai_loaded = False
+try:
+    from mieai import Mieai
+    mieai_loaded = True
+except:
+    # Virga can be run without MieAi, but mixed opacities are not available
+    raise Warning('MieAi not found, mixed cloud particles cannot be calculated')
+
 # ==== Local imports
 from .root_functions import (vfall,vfall_find_root,qvs_below_model,
                              find_cond_t, solve_force_balance)
@@ -27,7 +36,7 @@ from .direct_mmr_solver import direct_solver
 
 def compute(atmo, directory=None, as_dict=True, og_solver=True, direct_tol=1e-15,
             refine_TP=True, og_vfall=True, analytical_rg=True, do_virtual=True,
-            quick_mix=False):
+            mixed_opacity_type=None):
     """
     Top level program to run eddysed. Requires running `Atmosphere` class
     before running this.
@@ -59,9 +68,16 @@ def compute(atmo, directory=None, as_dict=True, og_solver=True, direct_tol=1e-15
     do_virtual : bool
         If the user adds an upper bound pressure that is too low. There are cases where
         a cloud wants to form off the grid towards higher pressures. This enables that.
-    quick_mix : bool, optional
-        Only used if atmo.mixed=True. If quick_mix=True, the opacities are calculated in
-        the Batch approximation (see Kiefer et al. 2024b)
+    mixed_opacity_type : str, optional
+        Only used if atmo.mixed=True. Defines opacity calculation of mixed cloud
+        particles options are:
+         - 'multi_modal' or None: uses the size distribution of each material to calculate
+            the VMRs and number densities.
+         - 'single_modal': uses fsed['mixed'] to calculate the size distribution and
+            number densities of cloud particles (if fsed is a float, this is
+            similar to 'multi_modal')
+         - 'quick': assumes islands of material (see Kiefer et al. 2024b).
+            Opacity calculation are the same as for non-mixed particles.
 
     Returns
     -------
@@ -215,8 +231,8 @@ def compute(atmo, directory=None, as_dict=True, og_solver=True, direct_tol=1e-15
     # albedo, and asymmetry parameter.
     opd, w0, g0, opd_gas = calc_optics(
         nwave, qc, qt, rg, reff, ndz, radius, dr, bin_min, bin_max, qext, qscat,
-        cos_qscat, atmo.sig, rmin, rmax, atmo.mixed, rho_p, wave_in, condensibles,
-        directory, atmo.dist, getattr(atmo, 'gamma_A', None), quick_mix,
+        cos_qscat, atmo.sig, rmin, rmax, rho_p, wave_in, condensibles, directory,
+        atmo.dist, getattr(atmo, 'gamma_A', None), atmo.mixed, mixed_opacity_type,
         verbose=atmo.verbose
     )
 
@@ -306,8 +322,9 @@ def create_dict(qc, qt, rg, reff, ndz,opd, w0, g0, opd_gas, wave, pressure, temp
     return output
 
 def calc_optics(nwave, qc, qt, rg, reff, ndz, radius, dr, bin_min, bin_max, qext, qscat,
-                cos_qscat, sig, rmin, rmax, mixed, rhop, wavelength, gas_name, directory,
-                dist='lognormal', gamma_A=None, quick_mix=False, verbose=False):
+                cos_qscat, sig, rmin, rmax, rhop, wavelength, gas_name, directory,
+                dist='lognormal', gamma_A=None, mixed=False, mixed_opacity_type='quick',
+                verbose=False):
     """
     Calculate spectrally-resolved profiles of optical depth, single-scattering
     albedo, and asymmetry parameter.
@@ -382,7 +399,9 @@ def calc_optics(nwave, qc, qt, rg, reff, ndz, radius, dr, bin_min, bin_max, qext
     nz = qc.shape[0]  # number of atmospheric lauyers
     ngas = qc.shape[1]  # number of gas-phase species
     nrad = len(radius)  # number of cloud particle radii
+    nw = wavelength.shape[0]  # number of wavelength points
     warning0 = ''  # warning string to print at end
+    wave = wavelength[:, 0]  # wavelengths (Input array has wavelength per species)
 
     # working and output arrays
     opd_layer = np.zeros((nz, ngas))  # optical depth per layer
@@ -394,18 +413,90 @@ def calc_optics(nwave, qc, qt, rg, reff, ndz, radius, dr, bin_min, bin_max, qext
     w0 = np.zeros((nz, nwave))  # single scattering albedo
     g0 = np.zeros((nz, nwave))  # asymmetry parameter
 
-    if mixed:
-        if not quick_mix:
-            raise ValueError("Proper cloud mixing is work in progress, please set "
-                             "quick_mix=True")
+    # Mixed particle working array
+    ndr_mixed = np.zeros((nz, nrad, len(gas_name[:-1])))  # number density of mixed part.
+    vmr_test = np.ones((2, nrad, ngas-1)) * 2  # check if mixed opacities need recalc.
+    qextm = np.zeros((nz, nw, nrad))  # mixed cloud particle extinction coefficient
+    qscam = np.zeros((nz, nw, nrad))  # mixed cloud particle scattering coefficient
+    cos_qscam = np.zeros((nz, nw, nrad)) # mixed cloud particle asymmetry coefficient
+    qet, qst, cqt = None, None, None  # default assignment
 
-        # if quick mix is selected, remove the mixed particle entry (always the last)
-        # from the opacity calculation.
-        ngas -= 1
-
-    # ==== Work in progress =============================================================
     # ===================================================================================
+    # Mixed opacity precalculation
+    # ===================================================================================
+    # The opacity calculation of mixed particles is done here since it depends on MMR.
+    # Mixed properties are determined by calculating the size distribution and mixing
+    # each bin. This can be done in one of three ways:
+    #   - 'quick' or None: assume homogenous materials (same as non-mixed)
+    #   - 'single_modal': Use fsed['mixed'] calculated rg['mixed'] to get size dist
+    #   - 'multi_model': Use indivdual fsed's for each material and mix per bin
+    if mixed:
 
+        # ==== Check if MieAi is loaded and can be used
+        if mixed_opacity_type in [None, 'multi_modal', 'single_model'] and not mieai_loaded:
+            print('WARNING: MieAi not loaded, change opacity mixing to "quick".')
+            mixed_opacity_type = 'quick'
+        else:
+            # TODO: move this outside function
+            ma = Mieai(use_ai=False)  # set up mieai class
+
+        # ==== Quick mix
+        # This does not use the mixed properties and assumes each material forms a
+        # little homogeneous island on the cloud particle.
+        if mixed_opacity_type in ['quick']:
+            ngas -= 1  # remove 'mixed' entry which is always the last one
+
+        # ==== Mixed particles
+        elif mixed_opacity_type in ['single_model', 'multi_model']:
+            for z in range(nz):
+                # reset working variables
+                vmr = {}  # VMR dict for mieai
+                vmr_tot = 0  # check if there are any cloud partilces
+
+                # ==== Calculate size distributions for each material (including mixed)
+                for g, gas in enumerate(gas_name):
+                    # get size distribution of particles
+                    if dist == 'lognormal':
+                        arg1 = dr / (np.sqrt(2. * np.pi) * radius * np.log(sig))
+                        arg2 = -np.log(radius / rg[z, g]) ** 2 / (2 * np.log(sig) ** 2)
+                        vl = arg1 * np.exp(arg2)
+                    else:  # dist == 'gamma':
+                        B = gamma_A / rg[z, g]
+                        lf = gamma_A * np.log(B) - gammaln(gamma_A)
+                        vl = dr * np.exp(lf + (gamma_A - 1) * np.log(radius) - B * radius)
+                    dist = vl / np.sum(vl)  # normalisation
+                    ndr_mixed[z, :, g] = np.nan_to_num(ndz[z, g] * dist)
+
+                    for g, gas in enumerate(gas_name[:-1]):
+                        if mixed_opacity_type == 'multi_modal':
+                            # get fraction from the number density VMR per bin
+                            val = ndr_mixed[z, :, g] / np.sum(ndr_mixed[z, :, :-1], axis=1)
+                        else: # mixed_opacity_type == 'single_modal'
+                            # get fraction from the total VMR
+                            val = np.ones((nrad,)) * ndz[z, g] / np.sum(ndz[z, :-1], axis=1)
+                        vmr[gas] = np.nan_to_num(val)
+                        vmr_test[0, :, g] = vmr[gas]  # remember values for next loop
+                        vmr_tot += np.sum(vmr[gas])  # check if some values are non-zero
+
+                # ==== Check if VMRs have changed, and only then re-calculate opacity
+                if np.any(np.abs((vmr_test[0] - vmr_test[1]) / vmr_test[0]) > 1e-4):
+                    # if there are no clouds, return no opacity
+                    if vmr_tot <= 0:
+                        qet, qst, cqt = 0, 0, 0
+
+                    # calcualte opacity using MieAi library
+                    else:
+                        qet, qst, asym = ma.grid_efficiencies(wave, radius * 1e4, vmr)
+                        cqt = qet * asym  # qcos according to Virga syntax
+                        # remeber the vmrs for the next run
+                        vmr_test[1] = vmr_test[0]
+
+                # set values (these are the old values if vmrs have not changed)
+                qextm[z], qscam[z], cos_qscam[z] = qet.T, qst.T, cqt.T
+
+        else:
+            raise ValueError('mixed_opacity_type not recognized (' +
+                             mixed_opacity_type + ')')
 
     # ===================================================================================
     # Calculate opacity of each cloud particle material
@@ -414,7 +505,7 @@ def calc_optics(nwave, qc, qt, rg, reff, ndz, radius, dr, bin_min, bin_max, qext
     for iz in range(nz):
         for igas in range(ngas):
             # Optical depth for conservative geometric scatterers
-            if ndz[iz,igas] > 0:
+            if ndz[iz, igas] > 0:
 
                 # precise warning for when particles are either above or below the grid
                 # defined by the .mieff files
@@ -443,15 +534,29 @@ def calc_optics(nwave, qc, qt, rg, reff, ndz, radius, dr, bin_min, bin_max, qext
                     r2 = rg[iz, igas]**2 * (gamma_A + 1) / gamma_A
                 opd_layer[iz, igas] = 2.*np.pi*r2*ndz[iz, igas]
 
-                # ==== Calculate normalization factor (forces lognormal sum = 1.0)
-                if dist == 'lognormal':
+                if mixed and mixed_opacity_type in ['single_modal', 'multi_modal']:
+                    # only mixed entry should be considered
+                    if igas != 'mixed':
+                        continue
+                    for irad in range(nrad):
+                        for iw in range(nwave):
+                            # total cloud particle cross section
+                            pir2ndz2 = np.pi * radius[irad]**2 * np.sum(ndr_mixed[iz, irad, :-1])
+                            # opacity of mixed particles
+                            scat_gas[iz, iw, igas] += qscam[iz, iw, irad] * pir2ndz2
+                            ext_gas[iz, iw, igas] += qextm[iz, iw, irad] * pir2ndz2
+                            cqs_gas[iz, iw, igas] += cos_qscam[iz, iw, irad] * pir2ndz2
+
+                elif dist == 'lognormal':
                     norm = 0.
+                    # ==== Calculate normalization factor (forces lognormal sum = 1.0)
                     for irad in range(nrad):
                         rr = radius[irad]
                         arg1 = dr[irad] / (np.sqrt(2.*np.pi) * rr * np.log(sig))
                         arg2 = -np.log(rr / rg[iz, igas])**2 / (2 * np.log(sig)**2)
                         norm = norm + arg1 * np.exp(arg2)
-                    norm = ndz[iz,igas] / norm
+                    norm = ndz[iz, igas] / norm
+                    # ==== Calculate opacity
                     for irad in range(nrad):
                         rr = radius[irad]
                         arg1 = dr[irad] / (np.sqrt(2. * np.pi) * np.log(sig))
@@ -463,6 +568,7 @@ def calc_optics(nwave, qc, qt, rg, reff, ndz, radius, dr, bin_min, bin_max, qext
                             cqs_gas[iz, iwave, igas] += cos_qscat[iwave, irad, igas] * pir2ndz
 
                 elif dist == 'gamma':
+                    # ==== Calculate normalization factor (forces lognormal sum = 1.0)
                     B = gamma_A / rg[iz, igas]
                     # Use ln_gamma instead of gamma for numerical stability for large gamma_A
                     log_B = np.log(B)
@@ -473,6 +579,7 @@ def calc_optics(nwave, qc, qt, rg, reff, ndz, radius, dr, bin_min, bin_max, qext
                         norm = (norm + dr[irad] * np.exp(log_norm_factor
                                 + (gamma_A - 1) * np.log(rr) - B * rr))
                     norm = ndz[iz,igas] / norm
+                    # ==== Calculate opacity
                     for irad in range(nrad):
                         rr = radius[irad]
                         pdf_rr = np.exp(log_norm_factor + (gamma_A - 1) * np.log(rr) - B * rr)
@@ -498,7 +605,7 @@ def calc_optics(nwave, qc, qt, rg, reff, ndz, radius, dr, bin_min, bin_max, qext
             print("Not doing sublayer as cloud deck at the bottom of pressure grid")
 
         # ==== Cloud smoothing
-        # Add 10 percent and 5 percent of the last cloud value below the cloud to
+        # Add 10, 5 and 1 percent of the last cloud value below the cloud to
         # ensure a smooth transition
         else:
             opd_layer[ibot+1, igas] = opd_layer[ibot, igas] * 0.1
@@ -530,7 +637,7 @@ def calc_optics(nwave, qc, qt, rg, reff, ndz, radius, dr, bin_min, bin_max, qext
                     w0[iz,iwave] = opd_scat / opd_ext
                     g0[iz,iwave] = cos_qs / opd_scat
 
-    # ==== calcualte odp_gas
+    # ==== calculate odp_gas
     for igas in range(ngas):
         opd_gas[0, igas] = opd_layer[0, igas]
 
@@ -539,7 +646,8 @@ def calc_optics(nwave, qc, qt, rg, reff, ndz, radius, dr, bin_min, bin_max, qext
 
     # ==== Check for warnings and return
     if warning != '' and verbose:
-        print(warning0 + warning+' Turn off warnings by setting verbose=False.')
+        print(warning0 + warning + ' Turn off warnings by setting verbose=False.')
+
     return opd, w0, g0, opd_gas
 
 

--- a/virga/justdoit.py
+++ b/virga/justdoit.py
@@ -426,11 +426,11 @@ def calc_optics(nwave, qc, qt, rg, reff, ndz, radius, dr, bin_min, bin_max, qext
         mixed_opacity_type = 'multi_modal'
 
     ma = Mieai(use_ai=False)  # set up mieai class
-    for g, gas in enumerate(gas_name[:-1]):
+    for g, gas in enumerate(gas_name):
         if gas =='mixed':
             continue
         vmr2 = {}
-        for v, gas2 in enumerate(gas_name[:-1]):
+        for v, gas2 in enumerate(gas_name):
             if gas2 =='mixed':
                 continue
             if gas2 == gas:

--- a/virga/justdoit.py
+++ b/virga/justdoit.py
@@ -426,11 +426,11 @@ def calc_optics(nwave, qc, qt, rg, reff, ndz, radius, dr, bin_min, bin_max, qext
         mixed_opacity_type = 'multi_modal'
 
     ma = Mieai(use_ai=False)  # set up mieai class
-    for g, gas in enumerate(gas_name):
+    for g, gas in enumerate(gas_name[:-1]):
         if gas =='mixed':
             continue
         vmr2 = {}
-        for v, gas2 in enumerate(gas_name):
+        for v, gas2 in enumerate(gas_name[:-1]):
             if gas2 =='mixed':
                 continue
             if gas2 == gas:
@@ -472,14 +472,14 @@ def calc_optics(nwave, qc, qt, rg, reff, ndz, radius, dr, bin_min, bin_max, qext
             for z in range(nz):
                 # reset working variables
                 vmr = {}  # VMR dict for mieai
-                vmr_tot = 0  # check if there are any cloud partilces
+                vmr_tot = 0  # check if there are any cloud particles
 
                 # ==== Calculate size distributions for each material (including mixed)
                 for g, gas in enumerate(gas_name[:-1]):
                     # get size distribution of particles
                     if dist == 'lognormal':
                         arg1 = dr / (np.sqrt(2. * np.pi) * radius * np.log(sig))
-                        arg2 = -np.log(radius / rg[z, g]) ** 2 / (2 * np.log(sig) ** 2)
+                        arg2 = -np.log(radius / rg[z, g])**2 / (2 * np.log(sig)**2)
                         vl = arg1 * np.exp(arg2)
                     else:  # dist == 'gamma':
                         B = gamma_A / rg[z, g]
@@ -491,7 +491,7 @@ def calc_optics(nwave, qc, qt, rg, reff, ndz, radius, dr, bin_min, bin_max, qext
                 for g, gas in enumerate(gas_name[:-1]):
                     if mixed_opacity_type == 'multi_modal':
                         # get fraction from the number density VMR per bin
-                        val = ndr_mixed[z, :, g] / np.sum(ndr_mixed[z, :], axis=1)
+                        val = ndr_mixed[z, :, g] / np.sum(ndr_mixed[z], axis=1)
                     else: # mixed_opacity_type == 'single_modal'
                         # get fraction from the total VMR
                         val = np.ones((nrad,)) * ndz[z, g] / np.sum(ndz[z, :-1], axis=1)
@@ -502,16 +502,16 @@ def calc_optics(nwave, qc, qt, rg, reff, ndz, radius, dr, bin_min, bin_max, qext
                 # ==== Check if VMRs have changed, and only then re-calculate opacity
                 if np.any(np.abs((vmr_test[0] - vmr_test[1]) / vmr_test[0]) > 1e-4):
                     # if there are no clouds, return no opacity
-                    if vmr_tot <= 0:
-                        qet, qst, cqt = 0, 0, 0
-
-                    # calcualte opacity using MieAi library
-                    else:
-                        qeti, qsti, asym = ma.grid_efficiencies(wave, radius * 1e4, vmr)
-                        cqti = qeti * asym  # qcos according to Virga syntax
-                        qet, qst, cqt = qeti.T, qsti.T, cqti.T  # change format
-                        # remeber the vmrs for the next run
-                        vmr_test[1] = vmr_test[0]
+                    # if vmr_tot <= 0:
+                    #     qet, qst, cqt = 0, 0, 0
+                    #
+                    # # calcualte opacity using MieAi library
+                    # else:
+                    qeti, qsti, asym = ma.grid_efficiencies(wave, radius * 1e4, vmr)
+                    cqti = qeti * asym  # qcos according to Virga syntax
+                    qet, qst, cqt = qeti.T, qsti.T, cqti.T  # change format
+                    # remeber the vmrs for the next run
+                    vmr_test[1] = vmr_test[0]
 
                 # set values (these are the old values if vmrs have not changed)
                 qextm[z], qscam[z], cos_qscam[z] = qet, qst, cqt

--- a/virga/justdoit.py
+++ b/virga/justdoit.py
@@ -25,7 +25,7 @@ try:
     mieai_loaded = True
 except:
     # Virga can be run without MieAi, but mixed opacities are not available
-    raise Warning('MieAi not found, mixed cloud particles cannot be calculated')
+    print('[WARNING] MieAi not found, mixed cloud particles cannot be calculated')
 
 # ==== Local imports
 from .root_functions import (vfall,vfall_find_root,qvs_below_model,


### PR DESCRIPTION
I added opacity calculation for mixed cloud particles. Since these have to be done after Virga ran, they cannot be precalculated. To speed up calculation, we use our newly developed opacity calculation tool MieAi. This library is also based on miepython, same as Virga uses.

To calculate opacities of mixed particles, there are 3 options:
- Quick: This is the same as non-mixed particles
- multi_modal: calculates the size distribution of each homogeneous particle and then mixes the materials wihin each size bin according to their VMR
- single_modal: calculates mixed opacity according to the total MMR at each pressure, assuming a size distribution according to fsed_mixed, which can be set the same or seperate from the fsed of each material.

Currently still missing:
- testing
- documentation